### PR TITLE
feat: Add marketplace module with RTC pricing

### DIFF
--- a/shaprai/marketplace/__init__.py
+++ b/shaprai/marketplace/__init__.py
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Elyan Labs
+"""ShaprAI Marketplace — Template marketplace with RTC pricing."""
+
+__all__ = ["registry", "pricing", "validator"]

--- a/shaprai/marketplace/cli.py
+++ b/shaprai/marketplace/cli.py
@@ -1,0 +1,198 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Elyan Labs
+"""Marketplace CLI commands for ShaprAI."""
+
+import click
+import yaml
+import json
+from pathlib import Path
+from typing import Optional
+
+from .registry import TemplateRegistry, Template
+from .pricing import PricingEngine, calculate_purchase
+from .validator import TemplateValidator, validate_template
+
+
+@click.group()
+def marketplace():
+    """Template marketplace commands."""
+    pass
+
+
+@marketplace.command()
+@click.option("--template", "-t", required=True, help="Path to template file (YAML/JSON)")
+@click.option("--price", "-p", required=True, type=int, help="Price in RTC")
+@click.option("--author", "-a", default=None, help="Author name (defaults to 'anonymous')")
+def publish(template: str, price: int, author: Optional[str]):
+    """Publish a template to the marketplace.
+    
+    Example:
+        shaprai marketplace publish --template my_agent.yaml --price 10
+    """
+    template_path = Path(template)
+    if not template_path.exists():
+        click.echo(f"Error: Template file not found: {template}", err=True)
+        return 1
+
+    # Validate the template
+    validator = TemplateValidator()
+    result = validator.validate_file(template_path)
+    
+    if not result.is_valid:
+        click.echo("Validation failed:", err=True)
+        for error in result.errors:
+            click.echo(f"  ❌ {error}", err=True)
+        return 1
+    
+    if result.warnings:
+        click.echo("Warnings:")
+        for warning in result.warnings:
+            click.echo(f"  ⚠️  {warning}")
+
+    # Load template content
+    content = template_path.read_text()
+    if content.strip().startswith("{"):
+        template_data = json.loads(content)
+    else:
+        template_data = yaml.safe_load(content)
+
+    # Validate price
+    pricing_engine = PricingEngine()
+    try:
+        pricing_engine.validate_price(price)
+    except ValueError as e:
+        click.echo(f"Error: {e}", err=True)
+        return 1
+
+    # Create template object
+    tmpl = Template(
+        name=template_data.get("name", template_path.stem),
+        version=template_data.get("version", "1.0.0"),
+        author=author or template_data.get("author", "anonymous"),
+        description=template_data.get("description", ""),
+        price_rtc=price,
+        tags=template_data.get("tags", []),
+        content=content,
+    )
+
+    # Publish to registry
+    registry = TemplateRegistry()
+    try:
+        registry.publish(tmpl)
+        click.echo(f"✅ Published {tmpl.name}@{tmpl.version} for {price} RTC")
+        click.echo(f"   Author: {tmpl.author}")
+        if tmpl.tags:
+            click.echo(f"   Tags: {', '.join(tmpl.tags)}")
+    except ValueError as e:
+        click.echo(f"Error: {e}", err=True)
+        return 1
+
+
+@marketplace.command()
+@click.option("--tag", "-t", default=None, help="Filter by tag")
+@click.option("--author", "-a", default=None, help="Filter by author")
+@click.option("--query", "-q", default=None, help="Search query")
+@click.option("--sort", "-s", default="downloads", type=click.Choice(["downloads", "recent", "price"]), help="Sort by")
+@click.option("--limit", "-l", default=20, help="Maximum results")
+def search(tag: Optional[str], author: Optional[str], query: Optional[str], sort: str, limit: int):
+    """Search templates in the marketplace.
+    
+    Example:
+        shaprai marketplace search --tag personality --sort downloads
+    """
+    registry = TemplateRegistry()
+    templates = registry.search(tag=tag, author=author, query=query, sort=sort, limit=limit)
+    
+    if not templates:
+        click.echo("No templates found.")
+        return
+    
+    click.echo(f"Found {len(templates)} templates:\n")
+    for tmpl in templates:
+        click.echo(f"  📦 {tmpl.name}@{tmpl.version}")
+        click.echo(f"     💰 {tmpl.price_rtc} RTC | 📥 {tmpl.download_count} downloads")
+        if tmpl.description:
+            desc = tmpl.description[:60] + "..." if len(tmpl.description) > 60 else tmpl.description
+            click.echo(f"     📝 {desc}")
+        click.echo()
+
+
+@marketplace.command()
+@click.option("--template", "-t", required=True, help="Template name with version (e.g., sophia-personality@1.2.3)")
+def buy(template: str):
+    """Buy a template from the marketplace.
+    
+    Example:
+        shaprai marketplace buy --template sophia-personality@1.2.3
+    """
+    # Parse template name and version
+    if "@" in template:
+        name, version = template.rsplit("@", 1)
+    else:
+        name = template
+        version = None
+    
+    registry = TemplateRegistry()
+    
+    # Get template
+    if version:
+        tmpl = registry.get(name, version)
+    else:
+        tmpl = registry.get_latest(name)
+    
+    if not tmpl:
+        click.echo(f"Error: Template '{template}' not found.", err=True)
+        return 1
+    
+    # Show preview (truncated)
+    click.echo(f"📦 {tmpl.name}@{tmpl.version}")
+    click.echo(f"💰 Price: {tmpl.price_rtc} RTC")
+    click.echo(f"👤 Author: {tmpl.author}")
+    if tmpl.description:
+        click.echo(f"📝 {tmpl.description}")
+    click.echo()
+    
+    # Calculate revenue split
+    split = calculate_purchase(tmpl.price_rtc, tmpl.name, tmpl.version)
+    click.echo("Revenue split:")
+    click.echo(f"  👤 Creator: {split['creator']['amount']} RTC (90%)")
+    click.echo(f"  🏛️  Protocol: {split['protocol']['amount']} RTC (5%)")
+    click.echo(f"  📡 Relay: {split['relay']['amount']} RTC (5%)")
+    click.echo()
+    
+    # Increment download count
+    registry.increment_downloads(tmpl.name, tmpl.version)
+    
+    # In a real implementation, this would transfer RTC tokens
+    click.echo("✅ Purchase recorded! (RTC transfer would happen here)")
+    click.echo(f"\nTemplate content preview (first 500 chars):")
+    click.echo("-" * 40)
+    click.echo(tmpl.content[:500] + "..." if len(tmpl.content) > 500 else tmpl.content)
+
+
+@marketplace.command()
+@click.option("--author", "-a", default=None, help="Filter by author")
+def list(author: Optional[str]):
+    """List templates (optionally by author).
+    
+    Example:
+        shaprai marketplace list --author me
+    """
+    registry = TemplateRegistry()
+    
+    if author:
+        templates = registry.list_by_author(author)
+    else:
+        templates = registry.search(limit=50)
+    
+    if not templates:
+        click.echo("No templates found.")
+        return
+    
+    click.echo(f"\n📚 {len(templates)} templates:\n")
+    for tmpl in templates:
+        click.echo(f"  📦 {tmpl.name}@{tmpl.version} - {tmpl.price_rtc} RTC")
+        click.echo(f"     👤 {tmpl.author} | 📥 {tmpl.download_count} downloads")
+        if tmpl.tags:
+            click.echo(f"     🏷️  {', '.join(tmpl.tags)}")
+        click.echo()

--- a/shaprai/marketplace/pricing.py
+++ b/shaprai/marketplace/pricing.py
@@ -1,0 +1,119 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Elyan Labs
+"""RTC pricing and revenue split calculation."""
+
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+
+@dataclass
+class RevenueSplit:
+    """Revenue split for a template purchase."""
+    creator_amount: int  # 90% to creator
+    protocol_amount: int  # 5% to ShaprAI development fund
+    relay_amount: int  # 5% to relay node
+    total_rtc: int
+    template_name: str
+    template_version: str
+    buyer_id: Optional[str] = None
+
+
+class PricingEngine:
+    """Calculate RTC pricing and revenue splits."""
+
+    # Revenue split percentages
+    CREATOR_SHARE = 0.90  # 90%
+    PROTOCOL_SHARE = 0.05  # 5%
+    RELAY_SHARE = 0.05  # 5%
+
+    def __init__(self, relay_node_id: Optional[str] = None):
+        self.relay_node_id = relay_node_id
+
+    def calculate_split(self, price_rtc: int, template_name: str, template_version: str) -> RevenueSplit:
+        """Calculate revenue split for a purchase.
+        
+        Args:
+            price_rtc: Total RTC price
+            template_name: Name of the template
+            template_version: Version of the template
+            
+        Returns:
+            RevenueSplit with amounts for each party
+        """
+        creator_amount = int(price_rtc * self.CREATOR_SHARE)
+        protocol_amount = int(price_rtc * self.PROTOCOL_SHARE)
+        relay_amount = price_rtc - creator_amount - protocol_amount  # Ensure we don't lose any RTC due to rounding
+
+        return RevenueSplit(
+            creator_amount=creator_amount,
+            protocol_amount=protocol_amount,
+            relay_amount=relay_amount,
+            total_rtc=price_rtc,
+            template_name=template_name,
+            template_version=template_version,
+        )
+
+    def validate_price(self, price_rtc: int) -> bool:
+        """Validate a template price.
+        
+        Args:
+            price_rtc: Proposed price in RTC
+            
+        Returns:
+            True if price is valid
+            
+        Raises:
+            ValueError: If price is invalid
+        """
+        if price_rtc < 0:
+            raise ValueError("Price cannot be negative")
+        if price_rtc > 100000:
+            raise ValueError("Price cannot exceed 100,000 RTC")
+        return True
+
+    def format_rtc(self, amount: int) -> str:
+        """Format RTC amount for display."""
+        return f"{amount} RTC"
+
+    def get_creator_share_percent(self) -> float:
+        """Get creator share as percentage."""
+        return self.CREATOR_SHARE * 100
+
+    def get_protocol_share_percent(self) -> float:
+        """Get protocol share as percentage."""
+        return self.PROTOCOL_SHARE * 100
+
+    def get_relay_share_percent(self) -> float:
+        """Get relay share as percentage."""
+        return self.RELAY_SHARE * 100
+
+
+def calculate_purchase(price_rtc: int, template_name: str, template_version: str) -> Dict:
+    """Convenience function to calculate a purchase.
+    
+    Args:
+        price_rtc: Total RTC price
+        template_name: Name of the template
+        template_version: Version of the template
+        
+    Returns:
+        Dict with revenue split details
+    """
+    engine = PricingEngine()
+    split = engine.calculate_split(price_rtc, template_name, template_version)
+    return {
+        "total_rtc": split.total_rtc,
+        "creator": {
+            "amount": split.creator_amount,
+            "percent": "90%",
+        },
+        "protocol": {
+            "amount": split.protocol_amount,
+            "percent": "5%",
+        },
+        "relay": {
+            "amount": split.relay_amount,
+            "percent": "5%",
+        },
+        "template": f"{template_name}@{template_version}",
+    }

--- a/shaprai/marketplace/registry.py
+++ b/shaprai/marketplace/registry.py
@@ -1,0 +1,207 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Elyan Labs
+"""Template registry with CRUD, search, and versioning."""
+
+import sqlite3
+import json
+from pathlib import Path
+from datetime import datetime
+from typing import Optional, List, Dict, Any
+from dataclasses import dataclass, asdict
+import semver
+
+
+@dataclass
+class Template:
+    """Template metadata and content."""
+    name: str
+    version: str
+    author: str
+    description: str
+    price_rtc: int
+    tags: List[str]
+    content: str
+    download_count: int = 0
+    created_at: Optional[str] = None
+    updated_at: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+class TemplateRegistry:
+    """SQLite-backed template registry."""
+
+    def __init__(self, db_path: Optional[Path] = None):
+        self.db_path = db_path or Path.home() / ".shaprai" / "marketplace.db"
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._init_db()
+
+    def _init_db(self) -> None:
+        """Initialize database schema."""
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute("""
+                CREATE TABLE IF NOT EXISTS templates (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    name TEXT NOT NULL,
+                    version TEXT NOT NULL,
+                    author TEXT NOT NULL,
+                    description TEXT,
+                    price_rtc INTEGER DEFAULT 0,
+                    tags TEXT,  -- JSON array
+                    content TEXT NOT NULL,
+                    download_count INTEGER DEFAULT 0,
+                    created_at TEXT,
+                    updated_at TEXT,
+                    UNIQUE(name, version)
+                )
+            """)
+            conn.execute("""
+                CREATE INDEX IF NOT EXISTS idx_templates_name ON templates(name)
+            """)
+            conn.execute("""
+                CREATE INDEX IF NOT EXISTS idx_templates_author ON templates(author)
+            """)
+            conn.execute("""
+                CREATE INDEX IF NOT EXISTS idx_templates_tags ON templates(tags)
+            """)
+
+    def publish(self, template: Template) -> bool:
+        """Publish a new template version. Returns False if version exists."""
+        # Validate semver
+        try:
+            semver.VersionInfo.parse(template.version)
+        except ValueError:
+            raise ValueError(f"Invalid semver version: {template.version}")
+
+        # Check for existing version
+        if self.get(template.name, template.version):
+            raise ValueError(f"Template {template.name}@{template.version} already exists")
+
+        now = datetime.utcnow().isoformat()
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                """
+                INSERT INTO templates
+                (name, version, author, description, price_rtc, tags, content, download_count, created_at, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    template.name,
+                    template.version,
+                    template.author,
+                    template.description,
+                    template.price_rtc,
+                    json.dumps(template.tags),
+                    template.content,
+                    template.download_count,
+                    now,
+                    now,
+                ),
+            )
+        return True
+
+    def get(self, name: str, version: str) -> Optional[Template]:
+        """Get a specific template version."""
+        with sqlite3.connect(self.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            row = conn.execute(
+                "SELECT * FROM templates WHERE name = ? AND version = ?",
+                (name, version),
+            ).fetchone()
+            if row:
+                return self._row_to_template(row)
+            return None
+
+    def get_latest(self, name: str) -> Optional[Template]:
+        """Get the latest version of a template."""
+        versions = self.list_versions(name)
+        if not versions:
+            return None
+        # Sort by semver and get latest
+        versions.sort(key=lambda v: semver.VersionInfo.parse(v), reverse=True)
+        return self.get(name, versions[0])
+
+    def list_versions(self, name: str) -> List[str]:
+        """List all versions of a template."""
+        with sqlite3.connect(self.db_path) as conn:
+            rows = conn.execute(
+                "SELECT version FROM templates WHERE name = ? ORDER BY created_at DESC",
+                (name,),
+            ).fetchall()
+            return [row[0] for row in rows]
+
+    def search(
+        self,
+        tag: Optional[str] = None,
+        author: Optional[str] = None,
+        query: Optional[str] = None,
+        sort: str = "downloads",
+        limit: int = 20,
+    ) -> List[Template]:
+        """Search templates by tag, author, or query."""
+        sql = "SELECT * FROM templates WHERE 1=1"
+        params = []
+
+        if tag:
+            sql += " AND tags LIKE ?"
+            params.append(f'%"{tag}"%')
+
+        if author:
+            sql += " AND author = ?"
+            params.append(author)
+
+        if query:
+            sql += " AND (name LIKE ? OR description LIKE ?)"
+            params.extend([f"%{query}%", f"%{query}%"])
+
+        # Sort
+        if sort == "downloads":
+            sql += " ORDER BY download_count DESC"
+        elif sort == "recent":
+            sql += " ORDER BY created_at DESC"
+        elif sort == "price":
+            sql += " ORDER BY price_rtc ASC"
+
+        sql += f" LIMIT {limit}"
+
+        with sqlite3.connect(self.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            rows = conn.execute(sql, params).fetchall()
+            return [self._row_to_template(row) for row in rows]
+
+    def increment_downloads(self, name: str, version: str) -> None:
+        """Increment download count for a template."""
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                "UPDATE templates SET download_count = download_count + 1 WHERE name = ? AND version = ?",
+                (name, version),
+            )
+
+    def list_by_author(self, author: str) -> List[Template]:
+        """List all templates by an author."""
+        return self.search(author=author, sort="recent")
+
+    def delete(self, name: str, version: str) -> bool:
+        """Delete a specific template version."""
+        with sqlite3.connect(self.db_path) as conn:
+            cursor = conn.execute(
+                "DELETE FROM templates WHERE name = ? AND version = ?",
+                (name, version),
+            )
+            return cursor.rowcount > 0
+
+    def _row_to_template(self, row: sqlite3.Row) -> Template:
+        """Convert database row to Template object."""
+        return Template(
+            name=row["name"],
+            version=row["version"],
+            author=row["author"],
+            description=row["description"] or "",
+            price_rtc=row["price_rtc"],
+            tags=json.loads(row["tags"]) if row["tags"] else [],
+            content=row["content"],
+            download_count=row["download_count"],
+            created_at=row["created_at"],
+            updated_at=row["updated_at"],
+        )

--- a/shaprai/marketplace/validator.py
+++ b/shaprai/marketplace/validator.py
@@ -1,0 +1,162 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Elyan Labs
+"""Template schema validation before publish."""
+
+import yaml
+import json
+from pathlib import Path
+from typing import Dict, List, Any, Optional, Tuple
+from dataclasses import dataclass
+
+
+@dataclass
+class ValidationResult:
+    """Result of template validation."""
+    is_valid: bool
+    errors: List[str]
+    warnings: List[str]
+
+
+class TemplateValidator:
+    """Validate template schema before publishing."""
+
+    REQUIRED_FIELDS = ["name", "version", "author", "model", "capabilities"]
+    OPTIONAL_FIELDS = ["description", "tags", "platforms", "training", "ethics"]
+
+    def validate(self, template_content: str) -> ValidationResult:
+        """Validate a template file.
+        
+        Args:
+            template_content: YAML or JSON content of the template
+            
+        Returns:
+            ValidationResult with validation status and any errors/warnings
+        """
+        errors = []
+        warnings = []
+
+        # Parse the template
+        try:
+            if template_content.strip().startswith("{"):
+                template = json.loads(template_content)
+            else:
+                template = yaml.safe_load(template_content)
+        except (yaml.YAMLError, json.JSONDecodeError) as e:
+            return ValidationResult(
+                is_valid=False,
+                errors=[f"Failed to parse template: {e}"],
+                warnings=[],
+            )
+
+        if not isinstance(template, dict):
+            return ValidationResult(
+                is_valid=False,
+                errors=["Template must be a YAML/JSON object"],
+                warnings=[],
+            )
+
+        # Check required fields
+        for field in self.REQUIRED_FIELDS:
+            if field not in template:
+                errors.append(f"Missing required field: {field}")
+
+        # Validate name
+        if "name" in template:
+            name = template["name"]
+            if not isinstance(name, str):
+                errors.append("name must be a string")
+            elif not name.replace("-", "").replace("_", "").isalnum():
+                errors.append("name must be alphanumeric (hyphens and underscores allowed)")
+
+        # Validate version (semver)
+        if "version" in template:
+            version = template["version"]
+            if not isinstance(version, str):
+                errors.append("version must be a string")
+            elif not self._is_valid_semver(version):
+                errors.append(f"version must be valid semver (e.g., 1.0.0): {version}")
+
+        # Validate author
+        if "author" in template:
+            author = template["author"]
+            if not isinstance(author, str):
+                errors.append("author must be a string")
+
+        # Validate model
+        if "model" in template:
+            model = template["model"]
+            if not isinstance(model, dict):
+                errors.append("model must be an object")
+            elif "base" not in model:
+                warnings.append("model.base is recommended for specifying the base model")
+
+        # Validate capabilities
+        if "capabilities" in template:
+            capabilities = template["capabilities"]
+            if not isinstance(capabilities, list):
+                errors.append("capabilities must be a list")
+            elif len(capabilities) == 0:
+                warnings.append("capabilities list is empty")
+
+        # Validate tags if present
+        if "tags" in template:
+            tags = template["tags"]
+            if not isinstance(tags, list):
+                errors.append("tags must be a list")
+            else:
+                for tag in tags:
+                    if not isinstance(tag, str):
+                        errors.append(f"tag must be a string: {tag}")
+
+        # Validate description if present
+        if "description" in template:
+            description = template["description"]
+            if not isinstance(description, str):
+                errors.append("description must be a string")
+            elif len(description) > 500:
+                warnings.append(f"description is long ({len(description)} chars, recommend < 500)")
+
+        return ValidationResult(
+            is_valid=len(errors) == 0,
+            errors=errors,
+            warnings=warnings,
+        )
+
+    def validate_file(self, template_path: Path) -> ValidationResult:
+        """Validate a template file from path.
+        
+        Args:
+            template_path: Path to the template file
+            
+        Returns:
+            ValidationResult with validation status
+        """
+        if not template_path.exists():
+            return ValidationResult(
+                is_valid=False,
+                errors=[f"Template file not found: {template_path}"],
+                warnings=[],
+            )
+
+        content = template_path.read_text()
+        return self.validate(content)
+
+    def _is_valid_semver(self, version: str) -> bool:
+        """Check if version is valid semver."""
+        import re
+        pattern = r"^(\d+)\.(\d+)\.(\d+)(?:-([a-zA-Z0-9.-]+))?(?:\+([a-zA-Z0-9.-]+))?$"
+        return bool(re.match(pattern, version))
+
+
+def validate_template(template_content: str) -> Tuple[bool, List[str], List[str]]:
+    """Convenience function to validate a template.
+    
+    Args:
+        template_content: YAML or JSON content of the template
+        
+    Returns:
+        Tuple of (is_valid, errors, warnings)
+    """
+    validator = TemplateValidator()
+    result = validator.validate(template_content)
+    return result.is_valid, result.errors, result.warnings

--- a/tests/test_marketplace.py
+++ b/tests/test_marketplace.py
@@ -1,0 +1,264 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Elyan Labs
+"""Unit tests for marketplace module."""
+
+import pytest
+import tempfile
+from pathlib import Path
+
+from shaprai.marketplace.registry import TemplateRegistry, Template
+from shaprai.marketplace.pricing import PricingEngine, calculate_purchase
+from shaprai.marketplace.validator import TemplateValidator, validate_template
+
+
+# ============== Registry Tests ==============
+
+class TestTemplateRegistry:
+    """Tests for TemplateRegistry."""
+
+    def setup_method(self):
+        self.temp_db = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self.registry = TemplateRegistry(db_path=Path(self.temp_db.name))
+
+    def teardown_method(self):
+        Path(self.temp_db.name).unlink(missing_ok=True)
+
+    def test_publish_template(self):
+        """Test publishing a template."""
+        template = Template(
+            name="test-agent",
+            version="1.0.0",
+            author="test-author",
+            description="Test template",
+            price_rtc=10,
+            tags=["test", "agent"],
+            content="name: test-agent\nversion: 1.0.0",
+        )
+        result = self.registry.publish(template)
+        assert result is True
+
+    def test_publish_duplicate_version_fails(self):
+        """Test that publishing duplicate version fails."""
+        template = Template(
+            name="test-agent",
+            version="1.0.0",
+            author="test-author",
+            description="Test template",
+            price_rtc=10,
+            tags=[],
+            content="test",
+        )
+        self.registry.publish(template)
+        
+        with pytest.raises(ValueError, match="already exists"):
+            self.registry.publish(template)
+
+    def test_get_template(self):
+        """Test retrieving a template."""
+        template = Template(
+            name="my-agent",
+            version="2.0.0",
+            author="author1",
+            description="Description",
+            price_rtc=25,
+            tags=["ai"],
+            content="content",
+        )
+        self.registry.publish(template)
+        
+        result = self.registry.get("my-agent", "2.0.0")
+        assert result is not None
+        assert result.name == "my-agent"
+        assert result.version == "2.0.0"
+        assert result.price_rtc == 25
+
+    def test_get_latest_template(self):
+        """Test getting latest version."""
+        for v in ["1.0.0", "1.1.0", "2.0.0"]:
+            template = Template(
+                name="evolving-agent",
+                version=v,
+                author="author",
+                description=f"Version {v}",
+                price_rtc=10,
+                tags=[],
+                content=f"version: {v}",
+            )
+            self.registry.publish(template)
+        
+        latest = self.registry.get_latest("evolving-agent")
+        assert latest.version == "2.0.0"
+
+    def test_search_by_tag(self):
+        """Test searching by tag."""
+        template1 = Template(
+            name="agent1", version="1.0.0", author="a",
+            description="", price_rtc=10, tags=["nlp", "chat"], content="",
+        )
+        template2 = Template(
+            name="agent2", version="1.0.0", author="a",
+            description="", price_rtc=10, tags=["vision"], content="",
+        )
+        self.registry.publish(template1)
+        self.registry.publish(template2)
+        
+        results = self.registry.search(tag="nlp")
+        assert len(results) == 1
+        assert results[0].name == "agent1"
+
+    def test_search_by_author(self):
+        """Test searching by author."""
+        template1 = Template(
+            name="agent1", version="1.0.0", author="alice",
+            description="", price_rtc=10, tags=[], content="",
+        )
+        template2 = Template(
+            name="agent2", version="1.0.0", author="bob",
+            description="", price_rtc=10, tags=[], content="",
+        )
+        self.registry.publish(template1)
+        self.registry.publish(template2)
+        
+        results = self.registry.search(author="alice")
+        assert len(results) == 1
+        assert results[0].author == "alice"
+
+    def test_increment_downloads(self):
+        """Test incrementing download count."""
+        template = Template(
+            name="popular", version="1.0.0", author="a",
+            description="", price_rtc=10, tags=[], content="",
+        )
+        self.registry.publish(template)
+        
+        self.registry.increment_downloads("popular", "1.0.0")
+        self.registry.increment_downloads("popular", "1.0.0")
+        
+        result = self.registry.get("popular", "1.0.0")
+        assert result.download_count == 2
+
+
+# ============== Pricing Tests ==============
+
+class TestPricingEngine:
+    """Tests for PricingEngine."""
+
+    def test_calculate_split(self):
+        """Test revenue split calculation."""
+        engine = PricingEngine()
+        split = engine.calculate_split(100, "test", "1.0.0")
+        
+        assert split.total_rtc == 100
+        assert split.creator_amount == 90  # 90%
+        assert split.protocol_amount == 5   # 5%
+        assert split.relay_amount == 5      # 5%
+
+    def test_calculate_split_uneven(self):
+        """Test split with uneven amounts."""
+        engine = PricingEngine()
+        split = engine.calculate_split(37, "test", "1.0.0")
+        
+        # 37 * 0.90 = 33.3 -> 33
+        # 37 * 0.05 = 1.85 -> 1
+        # Remainder goes to relay: 37 - 33 - 1 = 3
+        assert split.creator_amount == 33
+        assert split.protocol_amount == 1
+        assert split.relay_amount == 3
+        assert split.total_rtc == 37
+
+    def test_validate_price_positive(self):
+        """Test validating positive price."""
+        engine = PricingEngine()
+        assert engine.validate_price(0) is True
+        assert engine.validate_price(100) is True
+        assert engine.validate_price(10000) is True
+
+    def test_validate_price_negative_fails(self):
+        """Test that negative price fails."""
+        engine = PricingEngine()
+        with pytest.raises(ValueError, match="cannot be negative"):
+            engine.validate_price(-1)
+
+    def test_validate_price_too_high_fails(self):
+        """Test that too high price fails."""
+        engine = PricingEngine()
+        with pytest.raises(ValueError, match="cannot exceed"):
+            engine.validate_price(100001)
+
+    def test_calculate_purchase_convenience(self):
+        """Test convenience function."""
+        result = calculate_purchase(100, "agent", "1.0.0")
+        assert result["total_rtc"] == 100
+        assert result["creator"]["amount"] == 90
+        assert result["protocol"]["amount"] == 5
+        assert result["relay"]["amount"] == 5
+
+
+# ============== Validator Tests ==============
+
+class TestTemplateValidator:
+    """Tests for TemplateValidator."""
+
+    def test_validate_valid_template_yaml(self):
+        """Test validating valid YAML template."""
+        content = """
+name: my-agent
+version: 1.0.0
+author: test-author
+model:
+  base: gpt-4
+capabilities:
+  - chat
+  - code
+description: A test agent
+tags:
+  - ai
+  - assistant
+"""
+        validator = TemplateValidator()
+        result = validator.validate(content)
+        assert result.is_valid is True
+        assert len(result.errors) == 0
+
+    def test_validate_valid_template_json(self):
+        """Test validating valid JSON template."""
+        content = '{"name": "agent", "version": "1.0.0", "author": "test", "model": {"base": "gpt-4"}, "capabilities": ["chat"]}'
+        validator = TemplateValidator()
+        result = validator.validate(content)
+        assert result.is_valid is True
+
+    def test_validate_missing_required_field(self):
+        """Test that missing required field fails."""
+        content = "name: agent\nversion: 1.0.0"
+        validator = TemplateValidator()
+        result = validator.validate(content)
+        assert result.is_valid is False
+        assert any("author" in e for e in result.errors)
+        assert any("model" in e for e in result.errors)
+        assert any("capabilities" in e for e in result.errors)
+
+    def test_validate_invalid_semver(self):
+        """Test that invalid semver fails."""
+        content = "name: agent\nversion: not-a-version\nauthor: test\nmodel: {}\ncapabilities: []"
+        validator = TemplateValidator()
+        result = validator.validate(content)
+        assert result.is_valid is False
+        assert any("semver" in e.lower() for e in result.errors)
+
+    def test_validate_invalid_yaml(self):
+        """Test that invalid YAML fails."""
+        content = "name: [unclosed\nversion: 1.0.0"
+        validator = TemplateValidator()
+        result = validator.validate(content)
+        assert result.is_valid is False
+
+    def test_validate_template_convenience(self):
+        """Test convenience function."""
+        content = "name: a\nversion: 1.0.0\nauthor: b\nmodel: {}\ncapabilities: []"
+        is_valid, errors, warnings = validate_template(content)
+        assert is_valid is True
+        assert len(errors) == 0
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Implements #8

/claim #8

## Changes

- Add `shaprai/marketplace/` module with:
  - `registry.py` — Template CRUD, search, versioning with SQLite backend
  - `pricing.py` — RTC pricing with 90/5/5 revenue split
  - `validator.py` — Template schema validation before publish
  - `cli.py` — CLI commands for publish, search, buy, list
- Add unit tests: 19 passing tests covering all components

## Acceptance Criteria

- [x] `shaprai/marketplace/` module created with registry, pricing, validator
- [x] CLI commands: publish, search, buy, list
- [x] SQLite-backed registry
- [x] Revenue split computed correctly (90/5/5)
- [x] Template preview with truncated config
- [x] Version conflict detection
- [x] Unit tests for registry, pricing, and validation (19 passing)