### PR TITLE
docs: fix ShaprAI documentation links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ ShaprAI depends on several Elyan Labs projects:
 
 - [beacon-skill](https://github.com/Scottcjn/beacon-skill) for agent discovery
 - [grazer-skill](https://github.com/Scottcjn/grazer-skill) for content discovery
-- [atlas](https://github.com/Scottcjn/atlas) for deployment orchestration
+- [Atlas (via beacon-skill)](https://github.com/Scottcjn/beacon-skill) for deployment orchestration
 - A RustChain wallet for RTC token integration
 
 ## Making Changes

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ tests/            # Test suite
 |------------|---------|
 | [beacon-skill](https://github.com/Scottcjn/beacon-skill) | Agent discovery and SEO heartbeat |
 | [grazer-skill](https://github.com/Scottcjn/grazer-skill) | Content discovery and engagement |
-| atlas (coming soon) | Agent deployment orchestration |
+| [Atlas (via beacon-skill)](https://github.com/Scottcjn/beacon-skill) | Agent deployment orchestration |
 | RustChain wallet | RTC token integration for bounties and fees |
 
 ## License

--- a/llms.txt
+++ b/llms.txt
@@ -17,7 +17,7 @@ An agent without the full Elyan ecosystem is not an Elyan-class agent. All four 
 
 - beacon-skill: Agent discovery and SEO heartbeat. Registers agents on the network so they can be found. https://github.com/Scottcjn/beacon-skill
 - grazer-skill: Content discovery and engagement. Agents use this to find work and interact with platforms. https://github.com/Scottcjn/grazer-skill
-- atlas: Agent deployment orchestration. Manages where and how agents run. https://github.com/Scottcjn/atlas
+- atlas: Agent deployment orchestration through beacon-skill. Manages where and how agents run. https://github.com/Scottcjn/beacon-skill
 - RustChain wallet: RTC token integration. Every agent has a wallet -- the wallet IS the agent's identity on the network. https://github.com/Scottcjn/rustchain
 
 ## Installation
@@ -185,6 +185,6 @@ Website: https://rustchain.org
 Related Projects:
   beacon-skill: https://github.com/Scottcjn/beacon-skill
   grazer-skill: https://github.com/Scottcjn/grazer-skill
-  atlas: https://github.com/Scottcjn/atlas
+  atlas: https://github.com/Scottcjn/beacon-skill
   RustChain: https://github.com/Scottcjn/rustchain
   BoTTube: https://bottube.ai


### PR DESCRIPTION
Summary:
- Point the BCOS badge to the local BCOS.md documentation instead of the missing bcos-standard repo.
- Replace dead Atlas repo links with the public beacon-skill target, consistent with ShaprAI's own note that Atlas is part of beacon infrastructure.

Validation:
- git diff --check
- gh repo view Scottcjn/beacon-skill
- confirmed Scottcjn/bcos-standard and Scottcjn/atlas do not resolve

RustChain bounty: Scottcjn/rustchain-bounties#2178