### PR TITLE
docs: fix marketplace usage links

### DIFF
--- a/docs/marketplace/USAGE.md
+++ b/docs/marketplace/USAGE.md
@@ -328,6 +328,6 @@ shaprai marketplace status
 
 ## Additional Resources
 
-- [API Reference](../shaprai/marketplace/README.md#api-usage)
-- [Template Examples](examples/)
-- [Revenue Split Details](REVENUE.md)
+- [API Reference](../../shaprai/marketplace/README.md#api-usage)
+- [Template Examples](../../examples/)
+- [Revenue Split Details](../../shaprai/marketplace/README.md#revenue-split)


### PR DESCRIPTION
## Summary
- update the Marketplace Usage API reference link to the actual marketplace README path
- point Template Examples at the repository examples directory
- point Revenue Split Details at the existing marketplace README section

## Validation
- `test ! -e docs/shaprai/marketplace/README.md && test ! -e docs/marketplace/examples && test ! -e docs/marketplace/REVENUE.md`
- `test -f shaprai/marketplace/README.md && test -d examples`
- `rg -n "^## API Usage|^## Revenue Split" shaprai/marketplace/README.md`
- local relative-link check for `docs/marketplace/USAGE.md` -> `missing_relative_links []`
- `/Users/babybrr/Library/Python/3.9/bin/codespell docs/marketplace/USAGE.md --ignore-words-list=crate,fo,nd,te,ro`
- `git diff --check`

Bounty: https://github.com/Scottcjn/rustchain-bounties/issues/9018

Bounty/payment details will be handled outside the PR/dashboard; public proof is this PR.