### PR TITLE
docs: fix broken links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Sharpen raw models into principled, self-governing Elyan-class agents.**
 
-[![BCOS Certified](https://img.shields.io/badge/BCOS-Certified-blue)](https://github.com/Scottcjn/bcos-standard)
+[![BCOS Certified](https://img.shields.io/badge/BCOS-Certified-blue)](BCOS.md)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![PyPI](https://img.shields.io/pypi/v/shaprai)](https://pypi.org/project/shaprai/)
 
@@ -240,7 +240,7 @@ tests/            # Test suite
 |------------|---------|
 | [beacon-skill](https://github.com/Scottcjn/beacon-skill) | Agent discovery and SEO heartbeat |
 | [grazer-skill](https://github.com/Scottcjn/grazer-skill) | Content discovery and engagement |
-| [atlas](https://github.com/Scottcjn/atlas) | Agent deployment orchestration |
+| atlas (coming soon) | Agent deployment orchestration |
 | RustChain wallet | RTC token integration for bounties and fees |
 
 ## License


### PR DESCRIPTION
## Summary

Fixes two broken links in the ShaprAI README:

1. **BCOS badge link** — `https://github.com/Scottcjn/bcos-standard` returns 404 (repo does not exist). Changed to point to the local `BCOS.md` file, consistent with other Elyan Labs repos (grazer-skill, beacon-skill).

2. **Atlas prerequisite link** — `https://github.com/Scottcjn/atlas` returns 404 (repo does not exist). Marked as "coming soon" since the repo is referenced but not yet available.

## Testing
- Verified both URLs return 404 via GitHub API
- Confirmed `BCOS.md` exists in this repo
- Confirmed other Elyan Labs repos (grazer-skill, beacon-skill) use relative `BCOS.md` link for the same badge

## Related
RustChain Bounty #2178 — Fix typo/improve docs in Elyan Labs repo

Wallet: bai-su