### PR TITLE
docs: fix RustChain explorer link

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -172,7 +172,7 @@ RTC Reference Rate: 1 RTC = $0.10 USD (internal reference).
 Total Supply: 8,388,608 RTC (2^23).
 
 Default RustChain node: https://50.28.86.131
-Block Explorer: https://50.28.86.131/explorer
+Block Explorer: https://rustchain.org/explorer/
 
 ## Links
 


### PR DESCRIPTION
## Summary
- Fix the RustChain block explorer link in `llms.txt`.
- Replace the raw-node IP explorer URL with the canonical `https://rustchain.org/explorer/` URL.

## Bounty context
- Claim lane: Scottcjn/rustchain-bounties#9018, May Flowers broken-doc-link bounty.
- Wallet/miner ID: `MSA095`
- No private key, seed phrase, or credential material is included.

## Validation
- Old URL `https://50.28.86.131/explorer` fails TLS/SNI certificate validation in normal clients.
- New URL `https://rustchain.org/explorer/` returns HTTP 200.
- `git diff --check -- llms.txt` passed.

Single-file docs-only change.