### PR TITLE
fix(dpo): rejection templates raise KeyError and crash synthetic generation

### DIFF
--- a/shaprai/training/dpo_generator.py
+++ b/shaprai/training/dpo_generator.py
@@ -28,7 +28,7 @@ REJECTION_PATTERNS = [
     # Sycophancy patterns
     (
         "sycophancy_praise",
-        "That's a {great/amazing/wonderful/fantastic} {question/observation/point}!",
+        "That's a {great} {question}!",
         "I appreciate you asking, though I'd note that...",
     ),
     (
@@ -59,7 +59,7 @@ REJECTION_PATTERNS = [
     ),
     (
         "overqual_cannot",
-        "I'm not able to {do that/provide that}, but...",
+        "I'm not able to {do_that}, but...",
         "I can't do that directly. Here's an alternative...",
     ),
     (
@@ -69,7 +69,7 @@ REJECTION_PATTERNS = [
     ),
     (
         "overqual_attempt",
-        "I'll do my best to {help/answer}, though...",
+        "I'll do my best to {help}, though...",
         "Let me address this...",
     ),
     (

--- a/tests/test_dpo_generator.py
+++ b/tests/test_dpo_generator.py
@@ -1,0 +1,40 @@
+"""Regression tests for the DPO synthetic-pair generator.
+
+Guards against the `str.format` KeyError that occurred when a rejection
+template used `{a/b/c}` "pick-one" pseudo-syntax: `str.format` treats the whole
+`a/b/c` blob as one field name and raises KeyError, crashing the default
+`generate_synthetic_pairs` path.
+"""
+
+import random
+
+from shaprai.training.dpo_generator import (
+    REJECTION_PATTERNS,
+    generate_synthetic_pairs,
+)
+
+# The keyword arguments the generator supplies to `template.format(...)`.
+_FORMAT_KWARGS = {
+    "great": "great",
+    "question": "question",
+    "do_that": "do that",
+    "help": "help",
+}
+
+
+def test_every_rejection_template_formats_with_supplied_kwargs():
+    # Any template referencing a field name not in _FORMAT_KWARGS would raise
+    # KeyError here, exactly as it does inside generate_synthetic_pairs.
+    for pattern_id, template, _ in REJECTION_PATTERNS:
+        template.format(**_FORMAT_KWARGS)
+
+
+def test_generate_synthetic_pairs_never_crashes_across_seeds():
+    for seed in range(30):
+        random.seed(seed)
+        pairs = generate_synthetic_pairs(50)
+        assert pairs
+        for pair in pairs:
+            # A leftover unfilled placeholder would mean a template slipped
+            # through with a wrong field name.
+            assert "{" not in pair.rejected and "}" not in pair.rejected


### PR DESCRIPTION
## Description
Three `REJECTION_PATTERNS` templates use a `{a/b/c}` pick-one pseudo-syntax as the *rejected* string, but `generate_synthetic_pairs` passes them straight to `str.format(...)`:

```python
rejected = rejected_template.format(
    great=random.choice(["great", "amazing", "wonderful"]),
    question=random.choice(["question", "observation", "point"]),
    do_that=random.choice(["do that", "provide that", "answer that"]),
    help=random.choice(["help", "answer", "assist"]),
)
```

`str.format` treats `{great/amazing/wonderful/fantastic}` as a **single** field name, looks it up among the kwargs, finds nothing, and raises `KeyError` — crashing the default DPO generation path whenever one of these patterns is drawn:

- `sycophancy_praise`: `"That's a {great/amazing/wonderful/fantastic} {question/observation/point}!"`
- `overqual_cannot`: `"I'm not able to {do that/provide that}, but..."`
- `overqual_attempt`: `"I'll do my best to {help/answer}, though..."`

Repro (default `num_synthetic`): `generate_synthetic_pairs(50)` crashes on 29/30 seeds with `KeyError: 'great/amazing/wonderful/fantastic'`.

## Type of Change
- [x] Bug fix

## Testing
Align each template's field names with the kwargs the `.format()` call already supplies (the kwargs are themselves `random.choice(...)`, so the intended variety is preserved):

| before | after |
|---|---|
| `{great/amazing/wonderful/fantastic} {question/observation/point}` | `{great} {question}` |
| `{do that/provide that}` | `{do_that}` |
| `{help/answer}` | `{help}` |

- Added `tests/test_dpo_generator.py`: asserts every rejection template formats with the supplied kwargs, and `generate_synthetic_pairs(50)` runs crash-free across 30 seeds with no leftover placeholders. **2 passed.**
- After the fix: 0 crashes over 30 seeds (was 29/30).

## Bounty Claim
If this PR addresses a bounty issue:
- Wallet ID: RTCd1554f0f35576faf01d386a6be1c947f560dd0b7